### PR TITLE
feat: Add user and chat authorization commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,4 +185,4 @@ Koyeb is a developer-friendly serverless platform that allows you to deploy appl
   - The logs in the Koyeb dashboard for errors
   - That all environment variables are correctly set
   - That the webhook URL is correctly configured 
-  - ex0123456789012
+  - ex01234567890123


### PR DESCRIPTION
feat: Add user and chat authorization commands

Adds `/auth user <user_id>` and `/auth chat <chat_id>` commands to authorize users and group chats, respectively.  Users can obtain their user ID via the `/whoami` command.